### PR TITLE
Fix PayloadTooLargeError: Increase request size limits from 2mb to 5mb

### DIFF
--- a/api/server.ts
+++ b/api/server.ts
@@ -65,7 +65,7 @@ const allowedOperations = ['validateToken', 'addImpressionsURL', 'registerIntera
 const stripe = require('stripe')(process.env.STRIPE_PRIVATE_KEY);
 
 app.post('/stripe-hooks', express.raw({ type: 'application/json' }), stripeHooks);
-app.use(express.json({ limit: '2mb'}));
+app.use(express.json({ limit: '5mb'}));
 
 scheduleMonthlyEmails();
 
@@ -110,7 +110,7 @@ function dynamicCors(req: Request, res: Response, next: NextFunction) {
   app.use(express.static(join(resolve(), 'public', 'uploads')));
   app.use(cookieParser());
 
-  app.use(bodyParser.urlencoded({ extended: true, limit: '2mb' }));
+  app.use(bodyParser.urlencoded({ extended: true, limit: '5mb' }));
 
   app.get('/', (req, res) => {
     res.send('Hello orld!');
@@ -1707,7 +1707,7 @@ function dynamicCors(req: Request, res: Response, next: NextFunction) {
     },
   });
 
-  app.use('/graphql', express.json({ limit: '2mb' }));
+  app.use('/graphql', express.json({ limit: '5mb' }));
   serverGraph.applyMiddleware({ app, cors: false });
   
   // Initialize Sentry with tracing for GraphQL


### PR DESCRIPTION
- Updated express.json() limit from 2mb to 5mb
- Updated bodyParser.urlencoded() limit from 2mb to 5mb
- Updated GraphQL endpoint express.json() limit from 2mb to 5mb

This resolves PayloadTooLargeError when saving large accessibility reports to S3 storage via saveAccessibilityReport function.