### PR TITLE
Fix PayloadTooLargeError: Increase request size limits from 2mb to 5mb

### DIFF
--- a/api/server.ts
+++ b/api/server.ts
@@ -65,7 +65,7 @@ const allowedOperations = ['validateToken', 'addImpressionsURL', 'registerIntera
 const stripe = require('stripe')(process.env.STRIPE_PRIVATE_KEY);
 
 app.post('/stripe-hooks', express.raw({ type: 'application/json' }), stripeHooks);
-app.use(express.json({ limit: '2mb'}));
+app.use(express.json({ limit: '5mb'}));
 
 scheduleMonthlyEmails();
 
@@ -110,7 +110,7 @@ function dynamicCors(req: Request, res: Response, next: NextFunction) {
   app.use(express.static(join(resolve(), 'public', 'uploads')));
   app.use(cookieParser());
 
-  app.use(bodyParser.urlencoded({ extended: true, limit: '2mb' }));
+  app.use(bodyParser.urlencoded({ extended: true, limit: '5mb' }));
 
   app.get('/', (req, res) => {
     res.send('Hello orld!');
@@ -1707,7 +1707,7 @@ function dynamicCors(req: Request, res: Response, next: NextFunction) {
     },
   });
 
-  app.use('/graphql', express.json({ limit: '2mb' }));
+  app.use('/graphql', express.json({ limit: '5mb' }));
   serverGraph.applyMiddleware({ app, cors: false });
   
   // Initialize Sentry with tracing for GraphQL

--- a/api/server.ts
+++ b/api/server.ts
@@ -65,7 +65,6 @@ const allowedOperations = ['validateToken', 'addImpressionsURL', 'registerIntera
 const stripe = require('stripe')(process.env.STRIPE_PRIVATE_KEY);
 
 app.post('/stripe-hooks', express.raw({ type: 'application/json' }), stripeHooks);
-app.use(express.json({ limit: '5mb'}));
 
 scheduleMonthlyEmails();
 
@@ -109,6 +108,9 @@ function dynamicCors(req: Request, res: Response, next: NextFunction) {
 
   app.use(express.static(join(resolve(), 'public', 'uploads')));
   app.use(cookieParser());
+  
+  // Apply JSON parsing middleware after Stripe webhook to avoid interfering with raw body processing
+  app.use(express.json({ limit: '5mb'}));
 
   app.use(bodyParser.urlencoded({ extended: true, limit: '5mb' }));
 
@@ -1707,7 +1709,6 @@ function dynamicCors(req: Request, res: Response, next: NextFunction) {
     },
   });
 
-  app.use('/graphql', express.json({ limit: '5mb' }));
   serverGraph.applyMiddleware({ app, cors: false });
   
   // Initialize Sentry with tracing for GraphQL


### PR DESCRIPTION
### **User description**
- Updated express.json() limit from 2mb to 5mb
- Updated bodyParser.urlencoded() limit from 2mb to 5mb
- Updated GraphQL endpoint express.json() limit from 2mb to 5mb

This resolves PayloadTooLargeError when saving large accessibility reports to S3 storage via saveAccessibilityReport function.


___

### **PR Type**
Bug fix


___

### **Description**
- Increased Express.js request size limits from 2mb to 5mb

- Fixed PayloadTooLargeError for large accessibility reports

- Updated limits for JSON, URL-encoded, and GraphQL endpoints


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.ts</strong><dd><code>Increase request payload size limits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api/server.ts

<li>Updated express.json() limit from 2mb to 5mb<br> <li> Updated bodyParser.urlencoded() limit from 2mb to 5mb  <br> <li> Updated GraphQL endpoint express.json() limit from 2mb to 5mb


</details>


  </td>
  <td><a href="https://github.com/snayyar00/accessibility-widget/pull/130/files#diff-30c857590403c04863c43b01a72b9b1d4892fbbc173644e9bac6fd3a2b1d4251">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>