### PR TITLE
Fix middleware ordering: Move express.json after Stripe webhook route

### DIFF
--- a/api/server.ts
+++ b/api/server.ts
@@ -65,7 +65,6 @@ const allowedOperations = ['validateToken', 'addImpressionsURL', 'registerIntera
 const stripe = require('stripe')(process.env.STRIPE_PRIVATE_KEY);
 
 app.post('/stripe-hooks', express.raw({ type: 'application/json' }), stripeHooks);
-app.use(express.json({ limit: '5mb'}));
 
 scheduleMonthlyEmails();
 
@@ -109,6 +108,9 @@ function dynamicCors(req: Request, res: Response, next: NextFunction) {
 
   app.use(express.static(join(resolve(), 'public', 'uploads')));
   app.use(cookieParser());
+  
+  // Apply JSON parsing middleware after Stripe webhook to avoid interfering with raw body processing
+  app.use(express.json({ limit: '5mb'}));
 
   app.use(bodyParser.urlencoded({ extended: true, limit: '5mb' }));
 
@@ -1707,7 +1709,6 @@ function dynamicCors(req: Request, res: Response, next: NextFunction) {
     },
   });
 
-  app.use('/graphql', express.json({ limit: '5mb' }));
   serverGraph.applyMiddleware({ app, cors: false });
   
   // Initialize Sentry with tracing for GraphQL


### PR DESCRIPTION
- Moved express.json middleware from global scope to inside startServer function
- Positioned after Stripe webhook route to prevent interference with raw body processing
- Added explanatory comment about middleware ordering importance
- Removed duplicate GraphQL-specific express.json middleware
- Ensures Stripe webhooks receive raw request bodies for proper signature verification

Resolves PR feedback about middleware configuration order.