### PR TITLE
deleteSitesPlan fix

### DIFF
--- a/api/repository/sites_allowed.repository.ts
+++ b/api/repository/sites_allowed.repository.ts
@@ -111,21 +111,29 @@ export async function deleteSiteWithRelatedRecords(url: string, user_id: number)
 			
 			await Promise.all([
 				trx('impressions').where('site_id', siteId).del()
-					.then(count => console.log(`Deleted ${count} impressions`)),
+					.then(count => console.log(`Deleted ${count} impressions`))
+					.catch(err => console.log(`Impressions deletion skipped: ${err.message}`)),
 				trx('problem_reports').where('site_id', siteId).del()
-					.then(count => console.log(`Deleted ${count} problem_reports`)),
+					.then(count => console.log(`Deleted ${count} problem_reports`))
+					.catch(err => console.log(`Problem reports deletion skipped: ${err.message}`)),
 				trx('unique_visitors').where('site_id', siteId).del()
-					.then(count => console.log(`Deleted ${count} unique_visitors`)),
+					.then(count => console.log(`Deleted ${count} unique_visitors`))
+					.catch(err => console.log(`Unique visitors deletion skipped: ${err.message}`)),
 				trx('accessibility_reports').where('allowed_sites_id', siteId).del()
-					.then(count => console.log(`Deleted ${count} accessibility_reports`)),
+					.then(count => console.log(`Deleted ${count} accessibility_reports`))
+					.catch(err => console.log(`Accessibility reports deletion skipped: ${err.message}`)),
 				trx('accessibility_scans').where('site_id', siteId).del()
-					.then(count => console.log(`Deleted ${count} accessibility_scans`)),
+					.then(count => console.log(`Deleted ${count} accessibility_scans`))
+					.catch(err => console.log(`Accessibility scans deletion skipped: ${err.message}`)),
 				trx('widget_settings').where('allowed_site_id', siteId).del()
-					.then(count => console.log(`Deleted ${count} widget_settings`)),
+					.then(count => console.log(`Deleted ${count} widget_settings`))
+					.catch(err => console.log(`Widget settings deletion skipped: ${err.message}`)),
 				trx('sites_plans').where('allowed_site_id', siteId).del()
-					.then(count => console.log(`Deleted ${count} sites_plans`)),
+					.then(count => console.log(`Deleted ${count} sites_plans`))
+					.catch(err => console.log(`Sites plans deletion skipped: ${err.message}`)),
 				trx('site_permissions').where('allowed_site_id', siteId).del()
-					.then(count => console.log(`Deleted ${count} site_permissions`)),
+					.then(count => console.log(`Deleted ${count} site_permissions`))
+					.catch(err => console.log(`Site permissions deletion skipped: ${err.message}`)),
 			]);
 
 			await trx.raw('SET FOREIGN_KEY_CHECKS = 1');

--- a/api/services/allowedSites/plans-sites.service.ts
+++ b/api/services/allowedSites/plans-sites.service.ts
@@ -246,37 +246,56 @@ export async function deleteTrialPlan(id: number): Promise<true> {
 
 export async function deleteSitesPlan(id: number, hook = false): Promise<true> {
   try {
-    const sitePlan = await getSitePlanById(id);
+    let sitePlan = await getSitePlanById(id);
+
+    if(!sitePlan){
+      sitePlan = await getAnySitePlanById(id);
+    }
 
     if (!sitePlan) {
       throw new ApolloError('Can not find any user plan');
     }
 
-    const customer = await getSubcriptionCustomerIDBySubId(sitePlan.subcription_id);
-
     if (hook === false) {
-      await cancelSubcriptionBySubId(sitePlan.subcription_id);
-    }
-
-    let previous_plan;
-    try {
-      previous_plan = await getSitesPlanByCustomerIdAndSubscriptionId(customer, sitePlan.subcription_id);
-    } catch (error) {
-      console.log('err = ', error);
-    }
-
-    const updatePromises = previous_plan.map(async (plan) => {
       try {
-        // await deleteSitesPlan(plan.id, true);
-        await Promise.all([deleteSitePlanById(plan.id), deletePermissionBySitePlanId(plan.id)]);
-        console.log('Deleted Plan for site', plan.siteId);
-      } catch (error) {
-        console.log('Error Deleting Plan for site:', plan.siteId);
-        throw error;
+        await cancelSubcriptionBySubId(sitePlan.subcription_id);
+      } catch (error: any) {
+        if (error.message && error.message.includes('No such subscription')) {
+          console.log(`Subscription ${sitePlan.subcription_id} not found, skipping cancellation`);
+        } else {
+          console.log("Subscription cancel error = ",error);
+          throw error;
+        }
       }
-    });
+    }
 
-    await Promise.all(updatePromises);
+    try {
+      // await deleteSitesPlan(plan.id, true);
+      await Promise.all([deleteSitePlanById(sitePlan.id), deletePermissionBySitePlanId(sitePlan.id)]);
+    } catch (error) {
+      console.log('Error Deleting Plan for site:', sitePlan.allowed_site_id);
+      throw error;
+    }
+
+    // let previous_plan;
+    // try {
+    //   previous_plan = await getSitesPlanByCustomerIdAndSubscriptionId(customer, sitePlan.subcription_id);
+    // } catch (error) {
+    //   console.log('err = ', error);
+    // }
+
+    // const updatePromises = previous_plan.map(async (plan) => {
+    //   try {
+    //     // await deleteSitesPlan(plan.id, true);
+    //     await Promise.all([deleteSitePlanById(plan.id), deletePermissionBySitePlanId(plan.id)]);
+    //     console.log('Deleted Plan for site', plan.siteId);
+    //   } catch (error) {
+    //     console.log('Error Deleting Plan for site:', plan.siteId);
+    //     throw error;
+    //   }
+    // });
+
+    // await Promise.all(updatePromises);
     // await deleteSitesPlanById(sitePlan.id);
     // await Promise.all([deleteSitePlanById(sitePlan.id), deletePermissionBySitePlanId(sitePlan.id)]);
 
@@ -290,38 +309,59 @@ export async function deleteSitesPlan(id: number, hook = false): Promise<true> {
 
 export async function deleteExpiredSitesPlan(id: number, hook = false): Promise<true> {
   try {
-    const sitePlan = await getAnySitePlanById(id);
+    let sitePlan = await getAnySitePlanById(id);
+
+    if(!sitePlan){
+      sitePlan = await getAnySitePlanById(id);
+    }
 
     if (!sitePlan) {
       throw new ApolloError('Can not find any user plan');
     }
 
-    const customer = await getSubcriptionCustomerIDBySubId(sitePlan.subcription_id);
 
     if (hook === false) {
-      console.log("hook is not false")
-      await cancelSubcriptionBySubId(sitePlan.subcription_id);
-    }
-
-    let previous_plan;
-    try {
-      previous_plan = await getSitesPlanByCustomerIdAndSubscriptionId(customer, sitePlan.subcription_id);
-    } catch (error) {
-      console.log('err = ', error);
-    }
-
-    const updatePromises = previous_plan.map(async (plan) => {
       try {
-        // await deleteSitesPlan(plan.id, true);
-        await Promise.all([deleteSitePlanById(plan.id), deletePermissionBySitePlanId(plan.id)]);
-        console.log('Deleted Plan for site', plan.siteId);
-      } catch (error) {
-        console.log('Error Deleting Plan for site:', plan.siteId);
-        throw error;
+        await cancelSubcriptionBySubId(sitePlan.subcription_id);
+      } catch (error: any) {
+        if (error.message && error.message.includes('No such subscription')) {
+          console.log(`Subscription ${sitePlan.subcription_id} not found, skipping cancellation`);
+        } else {
+          console.log("Subscription cancel error = ",error);
+          throw error;
+        }
       }
-    });
+    }
 
-    await Promise.all(updatePromises);
+    try {
+      // await deleteSitesPlan(plan.id, true);
+      await Promise.all([deleteSitePlanById(sitePlan.id), deletePermissionBySitePlanId(sitePlan.id)]);
+    } catch (error) {
+      console.log('Error Deleting Plan for site:', sitePlan.allowed_site_id);
+      throw error;
+    }
+
+
+
+    // let previous_plan;
+    // try {
+    //   previous_plan = await getSitesPlanByCustomerIdAndSubscriptionId(customer, sitePlan.subcription_id);
+    // } catch (error) {
+    //   console.log('err = ', error);
+    // }
+
+    // const updatePromises = previous_plan.map(async (plan) => {
+    //   try {
+    //     // await deleteSitesPlan(plan.id, true);
+    //     await Promise.all([deleteSitePlanById(plan.id), deletePermissionBySitePlanId(plan.id)]);
+    //     console.log('Deleted Plan for site', plan.siteId);
+    //   } catch (error) {
+    //     console.log('Error Deleting Plan for site:', plan.siteId);
+    //     throw error;
+    //   }
+    // });
+
+    // await Promise.all(updatePromises);
     // await deleteSitesPlanById(sitePlan.id);
     // await Promise.all([deleteSitePlanById(sitePlan.id), deletePermissionBySitePlanId(sitePlan.id)]);
 

--- a/api/services/allowedSites/plans-sites.service.ts
+++ b/api/services/allowedSites/plans-sites.service.ts
@@ -311,10 +311,6 @@ export async function deleteExpiredSitesPlan(id: number, hook = false): Promise<
   try {
     let sitePlan = await getAnySitePlanById(id);
 
-    if(!sitePlan){
-      sitePlan = await getAnySitePlanById(id);
-    }
-
     if (!sitePlan) {
       throw new ApolloError('Can not find any user plan');
     }

--- a/api/services/stripe/subcription.service.ts
+++ b/api/services/stripe/subcription.service.ts
@@ -210,9 +210,9 @@ export async function cancelSubcriptionBySubId(subId: string): Promise<boolean> 
 
     return true;
   } catch (error) {
-    console.log("Sub del func error",error);
     logger.error(error);
-    throw new ApolloError('Something went wrong!');
+    throw error;
+    // throw new ApolloError('Something went wrong!');
   }
 }
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Enhanced error handling for subscription cancellation and database deletions

- Fixed site plan deletion logic to handle missing subscriptions gracefully

- Added fallback mechanisms for site plan retrieval

- Improved database deletion error handling with skip messages


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sites_allowed.repository.ts</strong><dd><code>Enhanced database deletion error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api/repository/sites_allowed.repository.ts

<li>Added <code>.catch()</code> handlers to all database deletion operations<br> <li> Enhanced error logging with descriptive skip messages<br> <li> Improved resilience for foreign key constraint deletions


</details>


  </td>
  <td><a href="https://github.com/snayyar00/accessibility-widget/pull/137/files#diff-96c558d3121c1cafb4d6256dc35564cf581316be4d735960fb4300f367fcaeaf">+16/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>subcription.service.ts</strong><dd><code>Improved subscription cancellation error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api/services/stripe/subcription.service.ts

<li>Modified <code>cancelSubcriptionBySubId</code> to throw original error instead of <br>generic ApolloError<br> <li> Removed redundant console.log statement<br> <li> Improved error propagation for better upstream handling


</details>


  </td>
  <td><a href="https://github.com/snayyar00/accessibility-widget/pull/137/files#diff-5843fbb42bd13e42584811a8602b0abaa86b5151e2487235a1946229fc520324">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>plans-sites.service.ts</strong><dd><code>Refactored site plan deletion with error resilience</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api/services/allowedSites/plans-sites.service.ts

<li>Added fallback site plan retrieval logic<br> <li> Wrapped subscription cancellation in try-catch with specific error <br>handling<br> <li> Simplified deletion logic by removing customer-based plan lookup<br> <li> Added graceful handling for missing subscriptions


</details>


  </td>
  <td><a href="https://github.com/snayyar00/accessibility-widget/pull/137/files#diff-66446750bdd89d965107b231b9b5339dba9c52e547b88282d2102dae3f7413bb">+77/-37</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>