### PR TITLE
Rate Limit Fix

### DIFF
--- a/api/graphql/schemas/impressions.schema.ts
+++ b/api/graphql/schemas/impressions.schema.ts
@@ -29,8 +29,8 @@ export const ImpressionsSchema = gql`
   }
 
   extend type Query {
-    getEngagementRates(url: String!, startDate: String, endDate: String): [engagementRate] @rateLimit(limit: 30, duration: 60, message: "Too many engagement rate requests. Please try again later.")
-    getImpressionsByURLAndDate(url: String!, startDate: String!, endDate: String!): ImpressionList @rateLimit(limit: 30, duration: 60, message: "Too many impression list requests. Please try again later.")
+    getEngagementRates(url: String!, startDate: String, endDate: String): [engagementRate] @rateLimit(limit: 60, duration: 60, message: "Too many engagement rate requests. Please try again later.")
+    getImpressionsByURLAndDate(url: String!, startDate: String!, endDate: String!): ImpressionList @rateLimit(limit: 60, duration: 60, message: "Too many impression list requests. Please try again later.")
   }
 
   extend type Mutation {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Increased rate limit from 30 to 60 requests per minute

- Applied to engagement rates and impressions queries


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Rate Limit: 30/min"] --> B["Rate Limit: 60/min"]
  B --> C["getEngagementRates"]
  B --> D["getImpressionsByURLAndDate"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>impressions.schema.ts</strong><dd><code>Doubled rate limit for impression queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api/graphql/schemas/impressions.schema.ts

<li>Updated rate limit from 30 to 60 requests per minute<br> <li> Applied to <code>getEngagementRates</code> and <code>getImpressionsByURLAndDate</code> queries<br> <li> Maintained same 60-second duration window


</details>


  </td>
  <td><a href="https://github.com/snayyar00/accessibility-widget/pull/187/files#diff-ea08bdc7aba55eb3017b87f279159502e62a65157898ca6e7f32525a964d9145">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>