### PR TITLE
fix: use backend URL for welcome email unsubscribe link

### DIFF
--- a/api/services/email/emailSequence.service.ts
+++ b/api/services/email/emailSequence.service.ts
@@ -93,7 +93,7 @@ export class EmailSequenceService {
           installationGuide: 'https://www.webability.io/installation',
           dashboardLink: frontendUrl,
           supportLink: 'mailto:support@webability.io',
-          unsubscribeLink: `${frontendUrl}/unsubscribe?email=${encodeURIComponent(userEmail)}`,
+          unsubscribeLink: `${process.env.REACT_APP_BACKEND_URL}/unsubscribe?email=${encodeURIComponent(userEmail)}`,
           year: new Date().getFullYear(),
         },
       })


### PR DESCRIPTION
- Change unsubscribe link in welcome email template to use REACT_APP_BACKEND_URL
- Ensures unsubscribe requests are properly routed to backend API
- Maintains consistency with backend-handled unsubscribe functionality