### PR TITLE
fix: resolve Day 1 email conditional subject line template compilation

### DIFF
--- a/api/services/email/emailSequence.service.ts
+++ b/api/services/email/emailSequence.service.ts
@@ -334,9 +334,12 @@ export class EmailSequenceService {
         },
       })
 
+      // Compile subject line for conditional content (Day 1 email has Handlebars syntax)
+      const compiledSubject = step.subject.includes('{{#if') ? (hasActiveDomains ? step.subject.replace(/{{#if hasActiveDomains}}(.*?){{else}}.*?{{\/if}}/g, '$1') : step.subject.replace(/{{#if hasActiveDomains}}.*?{{else}}(.*?){{\/if}}/g, '$1')) : step.subject
+
       // Send the email
       const emailToSend = this.getEmailForSending(user.email)
-      await sendEmailWithRetries(emailToSend, template, step.subject)
+      await sendEmailWithRetries(emailToSend, template, compiledSubject)
 
       // Mark email as sent in tracking system
       const emailLogKey = `${step.subject}|${user.id}`


### PR DESCRIPTION
### **User description**
- Fix Handlebars conditional syntax in email subject not being compiled
- Add regex-based subject resolution for hasActiveDomains condition
- Resolve 'Template Render Error' in Brevo for Day 1 follow-up emails
- Ensure users without domains get 'Setup Required' subject variant
- Maintain backward compatibility for static email subjects

Fixes issue where users (451) didn't receive Day 1 emails due to raw {{#if}} syntax being sent to Brevo instead of compiled subject text.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix Handlebars conditional syntax compilation in email subjects

- Add regex-based subject resolution for hasActiveDomains condition

- Resolve Brevo template render errors for Day 1 emails

- Ensure proper subject variants based on domain status


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Email Step Subject"] --> B["Check for {{#if}} syntax"]
  B --> C["Compile Subject with Regex"]
  C --> D["hasActiveDomains condition"]
  D --> E["Send Email with Compiled Subject"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>emailSequence.service.ts</strong><dd><code>Fix conditional email subject compilation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api/services/email/emailSequence.service.ts

<ul><li>Add conditional subject compilation logic for Handlebars syntax<br> <li> Implement regex-based replacement for <code>hasActiveDomains</code> conditions<br> <li> Replace raw subject with compiled subject in email sending<br> <li> Maintain backward compatibility for static subjects</ul>


</details>


  </td>
  <td><a href="https://github.com/snayyar00/accessibility-widget/pull/239/files#diff-f240d7eecf9725300a22e54245aa9d30affe63177a006503b5369520cc65be35">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

