### PR TITLE
wcag_code wont be affected by the gpt batch processing

### DIFF
--- a/api/services/accessibilityReport/gptBatch.service.ts
+++ b/api/services/accessibilityReport/gptBatch.service.ts
@@ -191,7 +191,7 @@ async function processBatch(batchId: string, issues: ProcessedIssue[], retryCoun
         description: enhancement.description || generateDetailedFallbackDescription(originalIssue),
         recommended_action: enhancement.recommended_action || generateDetailedFallbackAction(originalIssue),
         affected_disabilities: enhancement.affected_disabilities || generateFallbackDisabilities(originalIssue),
-        wcag_code: enhancement.wcag_code || originalIssue.wcag_code || extractWCAGCode(originalIssue.code) || 'N/A',
+        wcag_code: originalIssue.wcag_code || extractWCAGCode(originalIssue.code) || 'N/A',
       }
     })
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Preserve original `wcag_code` values in GPT batch processing

- Prevent GPT enhancement from overriding existing WCAG codes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Original Issue"] --> B["GPT Enhancement"]
  B --> C["Final Issue"]
  A -- "wcag_code preserved" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gptBatch.service.ts</strong><dd><code>Preserve original WCAG codes over GPT enhancements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api/services/accessibilityReport/gptBatch.service.ts

<ul><li>Modified WCAG code assignment logic to prioritize original issue <br>values<br> <li> Removed GPT enhancement override for <code>wcag_code</code> field</ul>


</details>


  </td>
  <td><a href="https://github.com/snayyar00/accessibility-widget/pull/279/files#diff-02c8beff26c4a7cc8bb52b21a763a10760b7dd626bfc382339389d2f0627a992">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

