### PR TITLE
Increase Node.js heap memory to resolve build issues

### DIFF
--- a/app/nixpacks.toml
+++ b/app/nixpacks.toml
@@ -1,5 +1,6 @@
 [variables]
 CI = 'false'
+NODE_OPTIONS = '--max-old-space-size=8192'
 
 [phases.setup]
 nixPkgs = ["nodejs_18", "curl", "wget", "nano"]

--- a/app/package.json
+++ b/app/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "craco start",
-    "build": "craco build --no-audit",
+    "build": "node --max-old-space-size=8192 node_modules/.bin/craco build --no-audit",
     "codegen": "graphql-codegen --config codegen.ts"
   },
   "dependencies": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased Node.js memory allocation to 8 GB during builds to improve build reliability and reduce out-of-memory failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->