### PR TITLE
feat: add API endpoint to search for sites by URL

### DIFF
--- a/api/controllers/sites.controller.ts
+++ b/api/controllers/sites.controller.ts
@@ -1,0 +1,39 @@
+import { Request, Response } from 'express'
+
+import { findSiteByURL } from '../repository/sites_allowed.repository'
+
+/**
+ * Find if domain URL is added using query parameter
+ * Endpoint: GET /api/sites/search?url=example.com
+ */
+export async function searchSiteByURL(req: Request, res: Response): Promise<Response> {
+  try {
+    const { url } = req.query
+
+    if (!url || typeof url !== 'string') {
+      return res.status(400).json({
+        error: 'URL query parameter is required',
+        message: 'Please provide a valid URL in the query parameters',
+      })
+    }
+
+    const site = await findSiteByURL(url)
+
+    if (!site) {
+      return res.status(404).json({
+        error: 'Site not found',
+        message: `No site found with URL: ${url}`,
+      })
+    }
+
+    return res.json({
+      success: true,
+    })
+  } catch (error) {
+    console.error('Error searching site by URL:', error)
+    return res.status(500).json({
+      error: 'Internal server error',
+      message: 'An error occurred while searching for the site',
+    })
+  }
+}

--- a/api/routes/index.ts
+++ b/api/routes/index.ts
@@ -5,6 +5,7 @@ import formRoutes from './form.routes'
 import monitoringRoutes from './monitoring.routes'
 import proofOfEffortRoutes from './proof-of-effort.routes'
 import reportsRoutes from './reports.routes'
+import sitesRoutes from './sites.routes'
 import stripeRoutes from './stripe.routes'
 import translationRoutes from './translation.routes'
 import widgetRoutes from './widget.routes'
@@ -19,5 +20,6 @@ router.use(formRoutes)
 router.use(proofOfEffortRoutes)
 router.use(chatRoutes)
 router.use(monitoringRoutes)
+router.use(sitesRoutes)
 
 export default router

--- a/api/routes/sites.routes.ts
+++ b/api/routes/sites.routes.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express'
+
+import { searchSiteByURL } from '../controllers/sites.controller'
+
+const router = Router()
+
+// Route to search site by URL query parameter
+router.get('/api/sites/search', searchSiteByURL)
+
+export default router


### PR DESCRIPTION
- Add sites.controller.ts with searchSiteByURL function
- Add sites.routes.ts with GET /api/sites/search endpoint
- Update routes/index.ts to include sites routes
- Endpoint allows searching for sites using query parameter ?url=example.com
- Returns success/error responses with proper HTTP status codes
- Auto-fixed linting and formatting issues